### PR TITLE
fix: sanitized negative scores

### DIFF
--- a/src/utils/comparator/scoreChecker.tsx
+++ b/src/utils/comparator/scoreChecker.tsx
@@ -1,6 +1,14 @@
 import Badge from "../../components/Badge";
 
 export const scoreChecker = (currentValue: number, previousValue: number) => {
+  if(currentValue < 0){
+    currentValue = 0;
+  }
+
+  if (previousValue < 0){
+    previousValue = 0;
+  }
+
   const result = currentValue - previousValue;
 
   if (result > 0) {


### PR DESCRIPTION
### Context
- Calculations should start on 0 and not on -1 when it comes to the score checker. This is due to the API returning scores at -1.
- Close #220 

### Changelog
- 6892570 fix: sanitized negative scores by @KoolTheba