### PR TITLE
Feature: replace minus one score

### DIFF
--- a/cypress/e2e/comparator.cy.ts
+++ b/cypress/e2e/comparator.cy.ts
@@ -104,7 +104,7 @@ describe("Comparator", () => {
       "Please check if the org/repository/commit has been analysed by the Scorecard.",
     );
   });
-  it("should compare data from each commit as expected", () => {
+  it.only("should compare data from each commit as expected", () => {
     cy.intercept(
       "GET",
       "https://api.securityscorecards.dev/projects/github.com/nodejs/node/?commit=2ac5e9889aba461f5a54d320973d2574980d206b",
@@ -177,31 +177,28 @@ describe("Comparator", () => {
       "contain",
       "Binary-Artifacts",
     );
-    cy.get('[data-testid="Binary-Artifacts"] > div > span')
+    cy.get('[data-testid="Binary-Artifacts-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Binary-Artifacts"] > span').should("contain", "0/10");
+    
+    cy.get('[data-testid="Binary-Artifacts-score"] > span').should("contain", "0/10");
 
     cy.get('[data-testid="Branch-Protection"]').should(
       "contain",
       "Branch-Protection",
     );
-    cy.get('[data-testid="Branch-Protection"] > div > span')
-      .should("contain", "Unchanged")
-      .and("have.css", "background-color")
-      .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Branch-Protection"] > span').should(
+    cy.get('[data-testid="Branch-Protection-score"] > abbr > span').should(
       "contain",
-      "-1/10",
+      "?",
     );
 
     cy.get('[data-testid="CI-Tests"]').should("contain", "CI-Tests");
-    cy.get('[data-testid="CI-Tests"] > div > span')
+    cy.get('[data-testid="CI-Tests-score"] > span')
       .should("contain", "Decreased -1")
       .and("have.css", "background-color")
       .and("eq", "rgb(220, 53, 69)");
-    cy.get('[data-testid="CI-Tests"] > span').and("contain", "9/10");
+    cy.get('[data-testid="CI-Tests-score"] > span').and("contain", "9/10");
     cy.get('[data-testid="CI-Tests"] ~ h4').should(
       "contain",
       "Additional details / variations",
@@ -211,42 +208,42 @@ describe("Comparator", () => {
       "contain",
       "CII-Best-Practices",
     );
-    cy.get('[data-testid="CII-Best-Practices"] > div > span')
+    cy.get('[data-testid="CII-Best-Practices-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="CII-Best-Practices"] > span').should(
+    cy.get('[data-testid="CII-Best-Practices-score"] > span').should(
       "contain",
       "5/10",
     );
 
     cy.get('[data-testid="Code-Review"]').should("contain", "Code-Review");
-    cy.get('[data-testid="Code-Review"] > div > span')
+    cy.get('[data-testid="Code-Review-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Code-Review"] > span').should("contain", "0/10");
+    cy.get('[data-testid="Code-Review-score"] > span').should("contain", "0/10");
     cy.get('[data-testid="Code-Review"] ~ h4').should(
       "contain",
       "Additional details / variations",
     );
 
     cy.get('[data-testid="Contributors"]').should("contain", "Contributors");
-    cy.get('[data-testid="Contributors"] > div > span')
+    cy.get('[data-testid="Contributors-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Contributors"] > span').should("contain", "10/10");
+    cy.get('[data-testid="Contributors-score"] > span').should("contain", "10/10");
 
     cy.get('[data-testid="Dangerous-Workflow"]').should(
       "contain",
       "Dangerous-Workflow",
     );
-    cy.get('[data-testid="Dangerous-Workflow"] > div > span')
+    cy.get('[data-testid="Dangerous-Workflow-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Dangerous-Workflow"] > span').should(
+    cy.get('[data-testid="Dangerous-Workflow-score"] > span').should(
       "contain",
       "10/10",
     );
@@ -255,56 +252,52 @@ describe("Comparator", () => {
       "contain",
       "Dependency-Update-Tool",
     );
-    cy.get('[data-testid="Dependency-Update-Tool"] > div > span')
+    cy.get('[data-testid="Dependency-Update-Tool-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Dependency-Update-Tool"] > span').should(
+    cy.get('[data-testid="Dependency-Update-Tool-score"] > span').should(
       "contain",
       "10/10",
     );
 
     cy.get('[data-testid="Fuzzing"]').should("contain", "Fuzzing");
-    cy.get('[data-testid="Fuzzing"] > div > span')
+    cy.get('[data-testid="Fuzzing-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Fuzzing"] > span').should("contain", "10/10");
+    cy.get('[data-testid="Fuzzing-score"] > span').should("contain", "10/10");
 
     cy.get('[data-testid="License"]').should("contain", "License");
-    cy.get('[data-testid="License"] > div > span')
+    cy.get('[data-testid="License-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="License"] > span').should("contain", "9/10");
+    cy.get('[data-testid="License-score"] > span').should("contain", "9/10");
 
     cy.get('[data-testid="Maintained"]').should("contain", "Maintained");
-    cy.get('[data-testid="Maintained"] > div > span')
+    cy.get('[data-testid="Maintained-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Maintained"] > span').should("contain", "10/10");
+    cy.get('[data-testid="Maintained-score"] > span').should("contain", "10/10");
     cy.get('[data-testid="Maintained"] ~ h4').should(
       "contain",
       "Additional details / variations",
     );
 
     cy.get('[data-testid="Packaging"]').should("contain", "Packaging");
-    cy.get('[data-testid="Packaging"] > div > span')
-      .should("contain", "Unchanged")
-      .and("have.css", "background-color")
-      .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Packaging"] > span').should("contain", "-1/10");
+    cy.get('[data-testid="Packaging-score"] > abbr > span').should("contain", "?");
 
     cy.get('[data-testid="Pinned-Dependencies"]').should(
       "contain",
       "Pinned-Dependencies",
     );
-    cy.get('[data-testid="Pinned-Dependencies"] > div > span')
+    cy.get('[data-testid="Pinned-Dependencies-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Pinned-Dependencies"] > span').should(
+    cy.get('[data-testid="Pinned-Dependencies-score"] > span').should(
       "contain",
       "7/10",
     );
@@ -314,41 +307,37 @@ describe("Comparator", () => {
     );
 
     cy.get('[data-testid="SAST"]').should("contain", "SAST");
-    cy.get('[data-testid="SAST"] > div > span')
+    cy.get('[data-testid="SAST-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="SAST"] > span').should("contain", "0/10");
+    cy.get('[data-testid="SAST-score"] > span').should("contain", "0/10");
 
     cy.get('[data-testid="Security-Policy"]').should(
       "contain",
       "Security-Policy",
     );
-    cy.get('[data-testid="Security-Policy"] > div > span')
+    cy.get('[data-testid="Security-Policy-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Security-Policy"] > span').should("contain", "10/10");
+    cy.get('[data-testid="Security-Policy-score"] > span').should("contain", "10/10");
 
     cy.get('[data-testid="Signed-Releases"]').should(
       "contain",
       "Signed-Releases",
     );
-    cy.get('[data-testid="Signed-Releases"] > div > span')
-      .should("contain", "Unchanged")
-      .and("have.css", "background-color")
-      .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Signed-Releases"] > span').should("contain", "-1/10");
+    cy.get('[data-testid="Signed-Releases-score"] > abbr > span').should("contain", "?");
 
     cy.get('[data-testid="Token-Permissions"]').should(
       "contain",
       "Token-Permissions",
     );
-    cy.get('[data-testid="Token-Permissions"] > div > span')
+    cy.get('[data-testid="Token-Permissions-score"] > span')
       .should("contain", "Unchanged")
       .and("have.css", "background-color")
       .and("eq", "rgb(108, 117, 125)");
-    cy.get('[data-testid="Token-Permissions"] > span').should(
+    cy.get('[data-testid="Token-Permissions-score"] > span').should(
       "contain",
       "10/10",
     );
@@ -361,11 +350,11 @@ describe("Comparator", () => {
       "contain",
       "Vulnerabilities",
     );
-    cy.get('[data-testid="Vulnerabilities"] > div > span')
+    cy.get('[data-testid="Vulnerabilities-score"] > span')
       .should("contain", "Increased 2.7")
       .and("have.css", "background-color")
       .and("eq", "rgb(24, 135, 84)");
-    cy.get('[data-testid="Vulnerabilities"] > span').should("contain", "10/10");
+    cy.get('[data-testid="Vulnerabilities-score"] > span').should("contain", "10/10");
     cy.get('[data-testid="Vulnerabilities"] ~ h4').should(
       "contain",
       "Additional details / variations",

--- a/cypress/e2e/visualizer.cy.ts
+++ b/cypress/e2e/visualizer.cy.ts
@@ -119,7 +119,7 @@ describe("Visualizer", () => {
       .and("contain", "0/10");
     cy.get('[data-testid="Branch-Protection"]')
       .should("contain", "Branch-Protection")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="CI-Tests"]')
       .should("contain", "CI-Tests")
       .and("contain", "9/10");
@@ -149,7 +149,7 @@ describe("Visualizer", () => {
       .and("contain", "10/10");
     cy.get('[data-testid="Packaging"]')
       .should("contain", "Packaging")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="Pinned-Dependencies"]')
       .should("contain", "Pinned-Dependencies")
       .and("contain", "7/10");
@@ -161,7 +161,7 @@ describe("Visualizer", () => {
       .and("contain", "10/10");
     cy.get('[data-testid="Signed-Releases"]')
       .should("contain", "Signed-Releases")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="Token-Permissions"]')
       .should("contain", "Token-Permissions")
       .and("contain", "10/10");
@@ -239,7 +239,7 @@ describe("Visualizer", () => {
       .and("contain", "0/10");
     cy.get('[data-testid="Branch-Protection"]')
       .should("contain", "Branch-Protection")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="CI-Tests"]')
       .should("contain", "CI-Tests")
       .and("contain", "9/10");
@@ -269,7 +269,7 @@ describe("Visualizer", () => {
       .and("contain", "10/10");
     cy.get('[data-testid="Packaging"]')
       .should("contain", "Packaging")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="Pinned-Dependencies"]')
       .should("contain", "Pinned-Dependencies")
       .and("contain", "7/10");
@@ -281,7 +281,7 @@ describe("Visualizer", () => {
       .and("contain", "10/10");
     cy.get('[data-testid="Signed-Releases"]')
       .should("contain", "Signed-Releases")
-      .and("contain", "-1/10");
+      .and("contain", "?");
     cy.get('[data-testid="Token-Permissions"]')
       .should("contain", "Token-Permissions")
       .and("contain", "10/10");

--- a/src/components/NoAvailableDataMark.tsx
+++ b/src/components/NoAvailableDataMark.tsx
@@ -1,0 +1,9 @@
+import "../styles/NoAvailableDataMark.css";
+
+export default function NoAvailableDataMark() {
+  return (
+    <abbr className="tooltip tooltip--top" data-tooltip="Data not available">
+      <span className="not-available-data">?</span>
+    </abbr>
+  );
+}

--- a/src/components/ProjectComparator.tsx
+++ b/src/components/ProjectComparator.tsx
@@ -154,7 +154,7 @@ function ProjectComparator() {
               <div data-testid={element.name} className="heading__wrapper">
                 <div className="info-badge__wrapper">
                   <h3>{element.name}</h3>
-                  <div className="info-score__wrapper">
+                  <div data-testid={`${element.name}-score`} className="info-score__wrapper">
                     {element.score >= 0 ? (
                       <>
                         {scoreChecker(element.score, element.prevScore)}

--- a/src/components/ProjectComparator.tsx
+++ b/src/components/ProjectComparator.tsx
@@ -7,6 +7,7 @@ import { scoreChecker } from "../utils/comparator/scoreChecker";
 import CommonError from "./CommonError";
 import Collapsible from "./Collapsable";
 import Loading from "./Loading";
+import NoAvailableDataMark from "./NoAvailableDataMark";
 import { ComparatorDiff } from "./ComparatorDiff";
 import { ScoreElement, ConsolidatedScoreElement } from "../types";
 import { getRefinedChecks } from "../utils/comparator/getRefinedChecks";
@@ -100,10 +101,7 @@ function ProjectComparator() {
   return (
     <>
       <h1>OpenSSF Scorecard comparator for {`${org}/${repo}`}</h1>
-      <div
-        data-testid="current-score-and-badge"
-        className="info-badge__wrapper"
-      >
+      <div data-testid="current-score-and-badge" className="score-wrapper">
         <h2>{`Current Score: ${currentData.score}/10`} </h2>
         {scoreChecker(currentData.score, previousData.score)}
       </div>
@@ -156,10 +154,19 @@ function ProjectComparator() {
               <div data-testid={element.name} className="heading__wrapper">
                 <div className="info-badge__wrapper">
                   <h3>{element.name}</h3>
-                  {scoreChecker(element.score, element.prevScore)}
+                  <div className="info-score__wrapper">
+                    {element.score >= 0 ? (
+                      <>
+                        {scoreChecker(element.score, element.prevScore)}
+                        <span>{element.score}/10</span>
+                      </>
+                    ) : (
+                      <NoAvailableDataMark />
+                    )}
+                  </div>
                 </div>
-                <span>{element.score}/10</span>
               </div>
+
               <p>
                 Description: {element.short.toLocaleLowerCase()}{" "}
                 <a href={`${element.url}`} target="_blank" rel="noreferrer">

--- a/src/components/ProjectDetails.tsx
+++ b/src/components/ProjectDetails.tsx
@@ -6,7 +6,7 @@ import { formatDate } from "../utils/formatDate";
 import CommonError from "./CommonError";
 import Collapsible from "./Collapsable";
 import Loading from "./Loading";
-
+import NoAvailableDataMark from "./NoAvailableDataMark";
 import { ScoreElement } from "../types";
 import { GITHUB } from "../constants/platforms";
 
@@ -93,7 +93,11 @@ function ProjectDetails() {
           <div key={element.name} className="card__wrapper">
             <div className="heading__wrapper" data-testid={element.name}>
               <h3>{element.name}</h3>
-              <span>{element.score}/10</span>
+              {element.score !== -1 ? (
+                <span>{element.score}/10</span>
+              ) : (
+                <NoAvailableDataMark />
+              )}
             </div>
             <p>
               Description: {element.documentation.short.toLocaleLowerCase()}{" "}

--- a/src/styles/Badge.css
+++ b/src/styles/Badge.css
@@ -1,10 +1,11 @@
 .badge {
   width: auto;
   padding: 0.4rem;
+  margin-right: 1rem;
   color: white;
   background-color: #6c757d;
   border-radius: 5px;
-  font-size: 1rem;
+  font-size: 14px;
   display: inline-block;
   font-weight: 600;
 }

--- a/src/styles/NoAvailableDataMark.css
+++ b/src/styles/NoAvailableDataMark.css
@@ -1,0 +1,63 @@
+.not-available-data {
+  display: inline-block;
+  color: red;
+  font-size: 24px;
+  font-weight: 900;
+}
+
+.tooltip {
+  position: relative;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%);
+  margin-bottom: 15px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 5px;
+  padding: 5px;
+}
+
+.tooltip::after {
+  position: absolute;
+  content: "";
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid rgba(0, 0, 0, 0.5);
+}
+
+.tooltip::before,
+.tooltip::after {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.tooltip:hover::before,
+.tooltip:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+.tooltip--top::before,
+.tooltip--top::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%);
+  margin-bottom: 15px;
+}
+
+.tooltip--top::after {
+  margin-bottom: 8px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid rgba(0, 0, 0, 0.5);
+}

--- a/src/styles/ProjectDetails.css
+++ b/src/styles/ProjectDetails.css
@@ -43,7 +43,6 @@ hr {
 div > div > span {
   font-size: 24px;
   font-weight: bold;
-  color: #007bff;
 }
 
 div > div > div {
@@ -96,8 +95,15 @@ a:hover {
 }
 
 .info-badge__wrapper {
+  width: 100%;
   display: flex;
   flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.info-score__wrapper {
+  display: flex;
   align-items: center;
 }
 


### PR DESCRIPTION
### Context
- Replaced by no-available data question mark and tooltip with extra info when the api doesn't send score (-1) for an specific check, while removing increase-decrease badge.
- Close #222 
<img width="941" alt="Captura de pantalla 2023-12-15 a las 19 24 47" src="https://github.com/KoolTheba/openssf-scorecard-api-visualizer/assets/26543236/62cd4da8-05d2-4793-b8c1-157cec84b2d5">

### Changelog
- eb913f4 feat: created mark and tooltip for unavailable data by @KoolTheba
- d790f3e feat: added logic for rendering mark by @KoolTheba
- 215b74a feat: improved styling by @KoolTheba
- 61bb8a3 test: adapted tests to latest changes by @KoolTheba